### PR TITLE
Fix incorrect script name and typos

### DIFF
--- a/graph_creation/node_labels.py
+++ b/graph_creation/node_labels.py
@@ -25,7 +25,7 @@ def convert_to_logic_string(input_string, gene_dict):
 
 def process_logic(expression):
     """
-    Evaluates a GPR rule logis string containing 'and', 'or', and parentheses.
+    Evaluates a GPR rule logic string containing 'and', 'or', and parentheses.
 
     Parameters:
     expression (str): The logic expression string to evaluate.
@@ -60,8 +60,8 @@ def process_logic(expression):
 
 def reaction_essentiality_calc(model, gene_essentiality_lookup):
     """
-    Calculates the essentiality of reactions in a metabolic model based on GPR rules and 
-    gene essenitlaity lables.
+    Calculates the essentiality of reactions in a metabolic model based on GPR rules and
+    gene essentiality labels.
 
     Parameters:
     model (cobra.Model): The metabolic model.


### PR DESCRIPTION
## Summary
- rename misnamed `node_lables.py` to `node_labels.py`
- fix typos in `node_labels.py` docstrings

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68445f616c148321b082c0e27970cfc7